### PR TITLE
fix: get testing again

### DIFF
--- a/.github/workflows/fw.yml
+++ b/.github/workflows/fw.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5.3.0
+        uses: fkirc/skip-duplicate-actions@v5.3.1
 
   build:
     needs: pre_job
@@ -20,35 +20,20 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-
-      - name: Cache build/
-        id: cache-build-dir
-        uses: actions/cache@v3
-        with:
-          path: build
-          key: build_cache
-
-      - name: Cache deps/
-        id: cache-deps-dir
-        uses: actions/cache@v3
-        with:
-          path: deps
-          key: deps_cache
-
-      - name: Cache .sconsign.dblite
-        id: cache-sconsign
-        uses: actions/cache@v3
-        with:
-          path: .sconsign.dblite
-          key: sconsign_cache
 
       - name: Set up Python
         run: |
           sudo apt-get update -yqq
           sudo apt-get install python3 python3-pip python3-venv -yqq
+
+      - name: Get x86 libraries
+        run: sudo apt-get install gcc-multilib -yqq
+
+      - name: Install PlatformIO
+        run: sudo pip install --upgrade platformio
 
       - name: Install scons
         run: pip install scons
@@ -63,7 +48,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: can-dbc
-          path: build/can/fsae_can.dbc
+          path: build/can/eol_can.dbc
 
       - name: Upload OpenCAN Codegen Artifacts
         uses: actions/upload-artifact@v3

--- a/dependencies.SConscript
+++ b/dependencies.SConscript
@@ -6,8 +6,8 @@ import os
 Import("env")
 
 # VERSIONS ------------------------------------------------
-env['ESP_RUST_VERSION'] = '1.69.0.0'
-env['RUST_VERSION']     = '1.68.2'
+env['ESP_RUST_VERSION'] = '1.70.0.0'
+env['RUST_VERSION']     = '1.70.0'
 env['OPENCAN_VERSION']  = 'b014266'
 # ---------------------------------------------------------
 
@@ -87,7 +87,7 @@ env['ESPUP'] = RUST_TOOLS_PATH.File('espup')
 espup_install_builder = env.Command(
   env['ESPUP'],
   env['CARGO'],
-  '$CARGO install espup'
+  '$CARGO install espup@0.8.0 --locked'
 )
 
 ESP_RUST_PATH     = env.Dir(env['ENV']['RUSTUP_HOME']).Dir('toolchains/espr')
@@ -104,7 +104,7 @@ esp_rust_install_builder = env.Command(
 # Update these as needed from esp-env.sh
 env.PrependENVPath('PATH', ESP_RUST_PATH.Dir('xtensa-esp32s3-elf/esp-2021r2-patch5-8_4_0/xtensa-esp32s3-elf/bin'))
 env.PrependENVPath('PATH', ESP_RUST_PATH.Dir('riscv32-esp-elf/esp-2021r2-patch5-8_4_0/riscv32-esp-elf/bin'))
-env['ENV']['LIBCLANG_PATH'] = ESP_RUST_PATH.Dir('xtensa-esp32-elf-clang/esp-15.0.0-20221201/esp-clang/lib').abspath
+env['ENV']['LIBCLANG_PATH'] = ESP_RUST_PATH.Dir('xtensa-esp32-elf-clang/esp-16.0.0-20230516/esp-clang/lib').abspath
 
 env.Alias('deps-esp-rust', esp_rust_install_builder)
 # ---------------------------------------------------------

--- a/eoltest/src/esp32.rs
+++ b/eoltest/src/esp32.rs
@@ -70,14 +70,30 @@ impl EolTest {
                     continue;
                 };
 
+                #[cfg(target_os = "macos")]
                 let normalized_dev_name = dev.port_name.replace("tty.usb", "cu.usb");
+                #[cfg(target_os = "linux")]
+                let normalized_dev_name = dev.port_name.clone();
+
+                #[cfg(target_os = "macos")]
                 let normalized_tester_name =
                     self.tester.name().unwrap().replace("tty.usb", "cu.usb");
+                #[cfg(target_os = "linux")]
+                let normalized_tester_name = self.tester.name().unwrap();
+
                 if normalized_dev_name == normalized_tester_name {
                     continue; // skip the tester
                 }
 
-                if product == "USB JTAG_serial debug unit" {
+                #[cfg(target_os = "macos")]
+                let expected_product_name = "USB JTAG_serial debug unit";
+
+                #[cfg(target_os = "linux")]
+                let expected_product_name = "USB_JTAG_serial_debug_unit";
+
+                debug!("checking device with product name ${product}");
+
+                if product == expected_product_name {
                     return Ok(dev.port_name);
                 }
             }

--- a/eoltest/src/tester.rs
+++ b/eoltest/src/tester.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use eol_shared::{TestResults, TEST_RESULT_START_MAGIC};
 
 use crate::EolTest;
+use tracing::debug;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -33,6 +34,9 @@ impl EolTest {
             let mut line = String::new();
 
             reader.read_line(&mut line).ok();
+            if line != "" {
+                debug!("DUT: {line}");
+            }
             if let Some(results) = line.strip_prefix(TEST_RESULT_START_MAGIC) {
                 if !got_first {
                     // skip the first result

--- a/fw/Cargo.lock
+++ b/fw/Cargo.lock
@@ -361,26 +361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
-dependencies = [
- "libc",
- "redox_users",
- "windows-sys 0.45.0",
-]
-
-[[package]]
 name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,17 +374,17 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "embuild"
-version = "0.31.1"
+version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "481bc7905b77810b66783faeb8c30d466fc7d128d7e4bdf2415e5f6ae1550dfe"
+checksum = "4caa4f198bb9152a55c0103efb83fa4edfcbb8625f4c9e94ae8ec8e23827c563"
 dependencies = [
  "anyhow",
  "bindgen 0.63.0",
  "bitflags",
  "cmake",
- "dirs",
  "filetime",
  "globwalk",
+ "home",
  "log",
  "remove_dir_all",
  "serde",
@@ -514,17 +494,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
-]
-
-[[package]]
 name = "git-version"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +556,15 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -849,17 +827,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall 0.2.16",
- "thiserror",
-]
-
-[[package]]
 name = "regex"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,7 +1078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi",
  "winapi",
 ]
 
@@ -1148,12 +1115,6 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1279,6 +1240,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.4",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,6 +1279,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,6 +1304,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1333,6 +1324,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,6 +1340,12 @@ name = "windows_i686_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1357,6 +1360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,6 +1376,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1381,6 +1396,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,3 +1412,9 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"

--- a/fw/Cargo.toml
+++ b/fw/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["src/dut", "src/tester", "src/shared"]
+resolver = "1"
 
 [patch.crates-io]
 # issue with lstat patch; will file esp-idf-sys issue, use my patch for now:

--- a/fw/SConscript
+++ b/fw/SConscript
@@ -8,7 +8,7 @@ flags_opt = AddOption('--pioflags',
     help='PlatformIO environment'
 )
 env['AddHelp']("fw --pioflags=FLAGS",
-               'Run pio for fw/ with FLAGS, e.g. `scons fw --pioflags="run -t dut"`')
+               'Run pio for fw/ with FLAGS, e.g. `scons fw --pioflags="run -e dut"`')
 
 pioflags = GetOption('pioflags')
 command = None
@@ -17,14 +17,21 @@ if pioflags is None:
 else:
     command = f'pio {pioflags} -d fw'
 
-[pio_builder] = env.Command(
+env_pio_builder = env.Clone()
+
+[pio_builder] = env_pio_builder.Command(
     env.Dir('.'),
     [],
     command
 )
-env.AlwaysBuild(pio_builder)
-env.Depends(pio_builder, env['PIP_PACKAGES'])
-env.Depends(pio_builder, env['ESP_CARGO'])
+
+env_pio_builder["ENV"]["PATH"] = ":".join(list(filter(lambda x: env["ENV"]["VIRTUAL_ENV"] not in x, env["ENV"]["PATH"].split(":"))))
+
+print(env_pio_builder["ENV"])
+
+env_pio_builder.AlwaysBuild(pio_builder)
+env_pio_builder.Depends(pio_builder, env['PIP_PACKAGES'])
+env_pio_builder.Depends(pio_builder, env['ESP_CARGO'])
 
 env.Alias('fw', pio_builder)
 env['AddHelp']('fw', 'Build fw')

--- a/fw/dependencies.lock
+++ b/fw/dependencies.lock
@@ -6,16 +6,16 @@ dependencies:
       type: service
     version: 1.1.0
   espressif/tinyusb:
-    component_hash: 820a2eef39c7ff0b810e859efd7035a4e5b9b44e77c49020a50ef0668fc941ae
+    component_hash: 6e128177d3fe5027750a75e1ff64c655a7b53fa64eff8c1a4a8a5a4daa7924d1
     source:
       service_url: https://api.components.espressif.com/
       type: service
-    version: 0.14.2
+    version: 0.15.0~7
   idf:
     component_hash: null
     source:
       type: idf
     version: 5.0.1
-manifest_hash: b3768303556f916e0c150f3fd46eb8b1173df306a15ca22bffac8028ddbf1e15
+manifest_hash: bb64d6f9353767e14cf5e178438e6ab6ab50a502985580b77b93bc12794e2904
 target: esp32s3
 version: 1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 cantools==38.0.2
 platformio==6.1.6
+setuptools


### PR DESCRIPTION
Did a bunch of work to get everything testing again properly. Add various updates to dependencies and build fixes. Add a few convenience flags for faster testing on already flashed boards. Add debugging information to report exact pin errors during tests. Made all parts fully compatible with running on Linux systems, instead of some parts working on darwin and some parts working on linux.

There are still some parts that need to be reworked to not break on updates but for now, it should be suitable to just have some paths updated manually whenever updating esp-idf, etc.